### PR TITLE
feat: replaced moq with NSubsitute

### DIFF
--- a/Unicorn.Contracts/ContractsService.Test/ContractsService.Tests.csproj
+++ b/Unicorn.Contracts/ContractsService.Test/ContractsService.Tests.csproj
@@ -10,11 +10,11 @@
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
         <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
         <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.9" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.17" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Unicorn.Contracts/ContractsService/ContractsService.csproj
+++ b/Unicorn.Contracts/ContractsService/ContractsService.csproj
@@ -17,8 +17,8 @@
         <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.1" />
         <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.3.2" />
         <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.1" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.9" />
-        <PackageReference Include="AWSSDK.EventBridge" Version="3.7.200.10" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.17" />
+        <PackageReference Include="AWSSDK.EventBridge" Version="3.7.200.16" />
         <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.12.0" />
     </ItemGroup>
 </Project>

--- a/Unicorn.Contracts/ContractsService/UpdateContractFunction.cs
+++ b/Unicorn.Contracts/ContractsService/UpdateContractFunction.cs
@@ -63,9 +63,9 @@ namespace Unicorn.Contracts.ContractService
         /// <param name="apigProxyEvent">API Gateway Lambda Proxy Request that triggers the function.</param>
         /// <param name="context">The context for the Lambda function.</param>
         /// <returns>API Gateway Lambda Proxy Response.</returns>
-        [Tracing]
+        [Logging(LogEvent = true)]
         [Metrics(CaptureColdStart = true)]
-        [Logging(LogEvent = true, CorrelationIdPath = CorrelationIdPaths.ApiGatewayRest)]
+        [Tracing(CaptureMode = TracingCaptureMode.ResponseAndError)]
         public async Task<APIGatewayProxyResponse> FunctionHandler(APIGatewayProxyRequest apigProxyEvent,
             ILambdaContext context)
         {

--- a/Unicorn.Properties/PropertiesService.Tests/PropertiesService.Tests.csproj
+++ b/Unicorn.Properties/PropertiesService.Tests/PropertiesService.Tests.csproj
@@ -8,9 +8,13 @@
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
         <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
+        <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Unicorn.Properties/PropertiesService/PropertiesService.csproj
+++ b/Unicorn.Properties/PropertiesService/PropertiesService.csproj
@@ -24,8 +24,8 @@
         <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.1" />
         <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.3.2" />
         <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.1" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.11" />
-        <PackageReference Include="AWSSDK.StepFunctions" Version="3.7.200.10" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.17" />
+        <PackageReference Include="AWSSDK.StepFunctions" Version="3.7.200.16" />
         <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.12.0" />
     </ItemGroup>
 </Project>

--- a/Unicorn.Web/ApprovalService.Tests/ApprovalService.Tests.csproj
+++ b/Unicorn.Web/ApprovalService.Tests/ApprovalService.Tests.csproj
@@ -14,11 +14,11 @@
         <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
         <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
         <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.9" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.17" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Unicorn.Web/ApprovalService/ApprovalService.csproj
+++ b/Unicorn.Web/ApprovalService/ApprovalService.csproj
@@ -17,8 +17,8 @@
         <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.1" />
         <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.3.2" />
         <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.1" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.9" />
-        <PackageReference Include="AWSSDK.EventBridge" Version="3.7.200.10" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.17" />
+        <PackageReference Include="AWSSDK.EventBridge" Version="3.7.200.16" />
         <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.12.0" />
     </ItemGroup>
 

--- a/Unicorn.Web/ApprovalService/RequestApprovalRequest.cs
+++ b/Unicorn.Web/ApprovalService/RequestApprovalRequest.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT-0
 
 using System.Text.Json.Serialization;
-using Unicorn.Web.Common;
 
 namespace Unicorn.Web.ApprovalService;
 

--- a/Unicorn.Web/Common/Common.csproj
+++ b/Unicorn.Web/Common/Common.csproj
@@ -12,8 +12,8 @@
       <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.6.0" />
       <PackageReference Include="Amazon.Lambda.CloudWatchEvents" Version="4.3.0" />
       <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-      <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.9" />
-      <PackageReference Include="AWSSDK.EventBridge" Version="3.7.200.10" />
+      <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.17" />
+      <PackageReference Include="AWSSDK.EventBridge" Version="3.7.200.16" />
       <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.12.0" />
     </ItemGroup>
 

--- a/Unicorn.Web/SearchService.Tests/SearchService.Tests.csproj
+++ b/Unicorn.Web/SearchService.Tests/SearchService.Tests.csproj
@@ -12,11 +12,11 @@
         <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
         <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.1" />
         <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.9" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.17" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Unicorn.Web/SearchService/SearchService.csproj
+++ b/Unicorn.Web/SearchService/SearchService.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="AWS.Lambda.Powertools.Logging" Version="1.1.1" />
         <PackageReference Include="AWS.Lambda.Powertools.Metrics" Version="1.3.2" />
         <PackageReference Include="AWS.Lambda.Powertools.Tracing" Version="1.1.1" />
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.9" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.200.17" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
**Issue number:**
#19 

## Summary
Removing the dependency to [Moq](https://www.nuget.org/packages/Moq) library and replace it with [NSubstitute](https://www.nuget.org/packages/NSubstitute) Version="5.0.0"


### Changes

All dependencies to Moq package are removed across all test projects Including all utilities as well as example test projects.

### User experience

This won't change any use experience as only test projects are updated.

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-samples/aws-serverless-developer-experience-workshop-dotnet/blob/develop/.github/semantic.yml)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
