### PR TITLE
fix: reverted how we reference namespaces

### DIFF
--- a/Unicorn.Contracts/template.yaml
+++ b/Unicorn.Contracts/template.yaml
@@ -37,8 +37,6 @@ Mappings:
     prod:
       Days: 14
   Constants:
-    ServiceNamespace:
-      Value: "unicorn.contracts"
     ProjectName:
       Value: "AWS Serverless Developer Experience"
 
@@ -60,35 +58,24 @@ Globals:
     Environment:
       Variables:
         DYNAMODB_TABLE: !Ref ContractsTable
-        SERVICE_NAMESPACE: !FindInMap [Constants, ServiceNamespace, Value]
+        SERVICE_NAMESPACE: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
         POWERTOOLS_LOGGER_CASE: PascalCase
-        POWERTOOLS_SERVICE_NAME: !FindInMap [Constants, ServiceNamespace, Value]
+        POWERTOOLS_SERVICE_NAME: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
         POWERTOOLS_TRACE_DISABLED: "false" # Explicitly disables tracing, default
         POWERTOOLS_LOGGER_LOG_EVENT: !If [IsProd, "false", "true"] # Logs incoming event, default
         POWERTOOLS_LOGGER_SAMPLE_RATE: !If [IsProd, "0.1", "0"] # Debug log sampling percentage, default
-        POWERTOOLS_METRICS_NAMESPACE: !FindInMap [
-            Constants,
-            ServiceNamespace,
-            Value,
-          ] # Metric Namespace
+        POWERTOOLS_METRICS_NAMESPACE: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}" # Metric Namespace
         LOG_LEVEL: INFO # Log level for Logger (INFO, DEBUG, etc.), default
     Tags:
       stage: !Ref Stage
       project: !FindInMap [Constants, ProjectName, Value]
-      namespace: !FindInMap [Constants, ServiceNamespace, Value]
+      namespace: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
 
 #### RESOURCES
 Resources:
 
   #### SSM PARAMETERS
-  # Services own and share their namespace
-  UnicornContractsNamespaceParam:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Type: String
-      Name: !Sub /uni-prop/${Stage}/UnicornContractsNamespace
-      Value: !FindInMap [Constants, ServiceNamespace, Value]
-
+  
   # Services share their event bus name and arn
   UnicornContractsEventBusNameParam:
     Type: AWS::SSM::Parameter
@@ -167,7 +154,7 @@ Resources:
       Tags:
         stage: !Ref Stage
         project: !FindInMap [Constants, ProjectName, Value]
-        namespace: !FindInMap [Constants, ServiceNamespace, Value]
+        namespace: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
 
   ContractsApiGwAccountConfig:
     Type: AWS::ApiGateway::Account
@@ -233,7 +220,7 @@ Resources:
         - Key: project
           Value: !FindInMap [Constants, ProjectName, Value]
         - Key: namespace
-          Value: !FindInMap [Constants, ServiceNamespace, Value]
+          Value: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
 
   UnicornContractsIngestDLQ:
     Type: AWS::SQS::Queue
@@ -249,7 +236,7 @@ Resources:
         - Key: project
           Value: !FindInMap [Constants, ProjectName, Value]
         - Key: namespace
-          Value: !FindInMap [Constants, ServiceNamespace, Value]
+          Value: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
 
   #### DYNAMODB TABLE
   ContractsTable:
@@ -272,7 +259,7 @@ Resources:
         - Key: project
           Value: !FindInMap [Constants, ProjectName, Value]
         - Key: namespace
-          Value: !FindInMap [Constants, ServiceNamespace, Value]
+          Value: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
 
   #### EVENT BUS
   # Event bus for Contract Service used to publish and consume events
@@ -297,7 +284,7 @@ Resources:
         Condition:
           StringEquals:
             events:source:
-              - !FindInMap [Constants, ServiceNamespace, Value]
+              - !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
 
   # Catchall rule used for development purposes.
   UnicornContractsCatchAllRule:
@@ -310,7 +297,7 @@ Resources:
         account:
           - !Ref AWS::AccountId
         source:
-          - !FindInMap [Constants, ServiceNamespace, Value]
+          - !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
       State: ENABLED #You may want to disable this rule in production
       Targets:
         - Arn: !GetAtt UnicornContractsCatchAllLogGroup.Arn
@@ -325,7 +312,7 @@ Resources:
       LogGroupName: !Sub
         - "/aws/events/${Stage}/${NS}-catchall"
         - Stage: !Ref Stage
-          NS: !FindInMap [Constants, ServiceNamespace, Value]
+          NS: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
       RetentionInDays: !FindInMap
         - LogsRetentionPeriodMap
         - !Ref Stage
@@ -386,7 +373,7 @@ Resources:
       Target: !GetAtt UnicornContractsEventBus.Arn
       TargetParameters:
         EventBridgeEventBusParameters:
-          Source: !FindInMap [Constants, ServiceNamespace, Value]
+          Source: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornContractsNamespace}}"
           DetailType: ContractStatusChanged
         InputTemplate: !ToJsonString
           PropertyId: "<$.dynamodb.NewImage.PropertyId.S>"

--- a/Unicorn.Properties/template.yaml
+++ b/Unicorn.Properties/template.yaml
@@ -10,9 +10,8 @@ Metadata:
   cfn-lint:
     config:
       ignore_checks:
-        - ES6000
-        - I3011
-        - I3013
+        - ES6000 # SQS redrive
+        - ES4000 #  EventBridge rule dlq
 
 #### PARAMETERS
 Parameters:
@@ -34,8 +33,6 @@ Mappings:
     prod:
       Days: 14
   Constants:
-    ServiceNamespace:
-      Value: "unicorn.properties"
     ProjectName:
       Value: "AWS Serverless Developer Experience"
 
@@ -58,31 +55,24 @@ Globals:
       Variables:
         CONTRACT_STATUS_TABLE: !Ref ContractStatusTable
         EVENT_BUS: !Ref UnicornPropertiesEventBus
-        SERVICE_NAMESPACE: !FindInMap [Constants, ServiceNamespace, Value]
+        SERVICE_NAMESPACE: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
         POWERTOOLS_LOGGER_CASE: PascalCase
-        POWERTOOLS_SERVICE_NAME: !FindInMap [Constants, ServiceNamespace, Value]
+        POWERTOOLS_SERVICE_NAME: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
         POWERTOOLS_TRACE_DISABLED: "false" # Explicitly disables tracing, default
         POWERTOOLS_LOGGER_LOG_EVENT: !If [IsProd, "false", "true"] # Logs incoming event, default
         POWERTOOLS_LOGGER_SAMPLE_RATE: !If [IsProd, "0.1", "0"] # Debug log sampling percentage, default
-        POWERTOOLS_METRICS_NAMESPACE: !FindInMap [Constants, ServiceNamespace, Value]
+        POWERTOOLS_METRICS_NAMESPACE: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
         LOG_LEVEL: INFO # Log level for Logger (INFO, DEBUG, etc.), default
     Tags:
       stage: !Ref Stage
       project: !FindInMap [ Constants, ProjectName, Value ]
-      namespace: !FindInMap [Constants, ServiceNamespace, Value]
+      namespace: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
 
 #### RESOURCES
 Resources:
 
   #### SSM PARAMETERS
-  # Services own and share their namespace
-  UnicornPropertiesNamespaceParam: 
-    Type: AWS::SSM::Parameter
-    Properties:
-      Type: String
-      Name: !Sub /uni-prop/${Stage}/UnicornPropertiesNamespace
-      Value: !FindInMap [Constants, ServiceNamespace, Value]
-      
+
   # Services share their event bus name and arn
   UnicornPropertiesEventBusNameParam:
     Type: AWS::SSM::Parameter
@@ -97,7 +87,6 @@ Resources:
       Type: String
       Name: !Sub /uni-prop/${Stage}/UnicornPropertiesEventBusArn
       Value: !GetAtt UnicornPropertiesEventBus.Arn
-
 
   #### LAMBDA FUNCTIONS
   ContractStatusChangedHandlerFunction:
@@ -205,7 +194,7 @@ Resources:
         - Key: project
           Value: !FindInMap [ Constants, ProjectName, Value ]
         - Key: namespace
-          Value: !FindInMap [Constants, ServiceNamespace, Value]
+          Value: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
         - Key: stage
           Value: !Ref Stage
 
@@ -220,7 +209,7 @@ Resources:
         - Key: project
           Value: !FindInMap [ Constants, ProjectName, Value ]
         - Key: namespace
-          Value: !FindInMap [Constants, ServiceNamespace, Value]
+          Value: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
         - Key: stage
           Value: !Ref Stage
 
@@ -265,30 +254,30 @@ Resources:
               LogGroupArn: !GetAtt ApprovalStateMachineLogGroup.Arn
         Level: ALL
         IncludeExecutionData: true
-      # Events:
-      #   PubApproReqEvent:
-      #     Type: EventBridgeRule
-      #     Properties:
-      #       RuleName: properties.pubapprovalwf-web.pubapprovalrequested
-      #       EventBusName: !GetAtt UnicornPropertiesEventBus.Name
-      #       Pattern:
-      #         source:
-      #           - !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
-      #         detail-type:
-      #           - PublicationApprovalRequested
-      #       RetryPolicy:
-      #         MaximumRetryAttempts: 5
-      #         MaximumEventAgeInSeconds: 900
-      #       DeadLetterConfig:
-      #         Type: SQS
-      #         Destination: !GetAtt PropertiesServiceDLQ.Arn
+      Events:
+        PubApproReqEvent:
+          Type: EventBridgeRule
+          Properties:
+            RuleName: properties.pubapprovalwf-web.pubapprovalrequested
+            EventBusName: !GetAtt UnicornPropertiesEventBus.Name
+            Pattern:
+              source:
+                - !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
+              detail-type:
+                - PublicationApprovalRequested
+            RetryPolicy:
+              MaximumRetryAttempts: 5
+              MaximumEventAgeInSeconds: 900
+            DeadLetterConfig:
+              Type: SQS
+              Destination: !GetAtt PropertiesServiceDLQ.Arn
       DefinitionSubstitutions:
         ContractExistsChecker: !GetAtt ContractExistsCheckerFunction.Arn
         WaitForContractApproval: !GetAtt WaitForContractApprovalFunction.Arn
         ContentIntegrityValidator: !GetAtt ContentIntegrityValidatorFunction.Arn
         ImageUploadBucketName: !Sub "{{resolve:ssm:/uni-prop/${Stage}/ImagesBucket}}"
         EventBusName: !GetAtt UnicornPropertiesEventBus.Name
-        ServiceName: !FindInMap [Constants, ServiceNamespace, Value]
+        ServiceName: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
 
   #### CLOUDWATCH LOG GROUPS
   ContractStatusChangedHandlerFunctionLogGroup:
@@ -358,7 +347,7 @@ Resources:
         - Key: project
           Value: !FindInMap [ Constants, ProjectName, Value ]
         - Key: namespace
-          Value: !FindInMap [Constants, ServiceNamespace, Value]
+          Value: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
         - Key: stage
           Value: !Ref Stage
 
@@ -387,7 +376,7 @@ Resources:
         Condition:
           StringEquals:
             events:source:
-              - !FindInMap [Constants, ServiceNamespace, Value]
+              - !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
 
   # Catchall rule used for development purposes.
   UnicornPropertiesCatchAllRule:
@@ -400,7 +389,7 @@ Resources:
         account:
           - !Ref AWS::AccountId
         source:
-          - !FindInMap [Constants, ServiceNamespace, Value]
+          - !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
       State: ENABLED #You may want to disable this rule in production
       Targets:
         - Arn: !GetAtt UnicornPropertiesCatchAllLogGroup.Arn
@@ -415,7 +404,7 @@ Resources:
       LogGroupName: !Sub
         - "/aws/events/${Stage}/${NS}-catchall"
         - Stage: !Ref Stage
-          NS: !FindInMap [Constants, ServiceNamespace, Value]
+          NS: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornPropertiesNamespace}}"
       RetentionInDays: !FindInMap [LogsRetentionPeriodMap, !Ref Stage, Days]
 
   # Permissions to allow EventBridge to send logs to CloudWatch

--- a/Unicorn.Web/template.yaml
+++ b/Unicorn.Web/template.yaml
@@ -16,7 +16,6 @@ Metadata:
         - ES1001
         - ES1007
         - ES6000
-        - WS2001
 
 #### PARAMETERS
 Parameters:
@@ -62,30 +61,23 @@ Globals:
       Variables:
         DYNAMODB_TABLE: !Ref WebTable
         EVENT_BUS: !Ref UnicornWebEventBus
-        SERVICE_NAMESPACE: !FindInMap [Constants, ServiceNamespace, Value]
+        SERVICE_NAMESPACE: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
         POWERTOOLS_LOGGER_CASE: PascalCase
-        POWERTOOLS_SERVICE_NAME: !FindInMap [Constants, ServiceNamespace, Value]
+        POWERTOOLS_SERVICE_NAME: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
         POWERTOOLS_TRACE_DISABLED: "false" # Explicitly disables tracing, default
         POWERTOOLS_LOGGER_LOG_EVENT: !If [IsProd, "false", "true"] # Logs incoming event, default
         POWERTOOLS_LOGGER_SAMPLE_RATE: !If [IsProd, "0.1", "0"] # Debug log sampling percentage, default
-        POWERTOOLS_METRICS_NAMESPACE: !FindInMap [Constants, ServiceNamespace, Value]
+        POWERTOOLS_METRICS_NAMESPACE: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
         POWERTOOLS_LOG_LEVEL: INFO # Log level for Logger (INFO, DEBUG, etc.), default
     Tags:
       stage: !Ref Stage
       project: !FindInMap [Constants, ProjectName, Value]
-      namespace: !FindInMap [Constants, ServiceNamespace, Value]
+      namespace: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
 
 ##### RESOURCES
 Resources:
   #### SSM PARAMETERS
-  # Services own and share their namespace
-  UnicornWebNamespaceParam:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Type: String
-      Name: !Sub /uni-prop/${Stage}/UnicornWebNamespace
-      Value: !FindInMap [Constants, ServiceNamespace, Value]
-
+  
   UnicornWebEventBusParam:
     Type: AWS::SSM::Parameter
     Properties:
@@ -285,7 +277,7 @@ Resources:
         - Key: project
           Value: !FindInMap [Constants, ProjectName, Value]
         - Key: namespace
-          Value: !FindInMap [Constants, ServiceNamespace, Value]
+          Value: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
 
   UnicornWebIngestDLQ:
     Type: AWS::SQS::Queue
@@ -301,7 +293,7 @@ Resources:
         - Key: project
           Value: !FindInMap [Constants, ProjectName, Value]
         - Key: namespace
-          Value: !FindInMap [Constants, ServiceNamespace, Value]
+          Value: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
 
   ##### DYNAMODB
   WebTable:
@@ -324,7 +316,7 @@ Resources:
         - Key: project
           Value: !FindInMap [Constants, ProjectName, Value]
         - Key: namespace
-          Value: !FindInMap [Constants, ServiceNamespace, Value]
+          Value: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
         - Key: stage
           Value: !Ref Stage
 
@@ -351,7 +343,7 @@ Resources:
         Condition:
           StringEquals:
             events:source:
-              - !FindInMap [Constants, ServiceNamespace, Value]
+              - !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
 
   # Catchall rule used for development purposes.
   UnicornWebCatchAllRule:
@@ -369,7 +361,7 @@ Resources:
         account:
           - !Ref AWS::AccountId
         source:
-          - !FindInMap [Constants, ServiceNamespace, Value]
+          - !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
       State: ENABLED #You may want to disable this rule in production
       Targets:
         - Arn: !GetAtt UnicornWebCatchAllLogGroup.Arn
@@ -384,7 +376,7 @@ Resources:
       LogGroupName: !Sub
         - "/aws/events/${Stage}/${NS}-catchall"
         - Stage: !Ref Stage
-          NS: !FindInMap [Constants, ServiceNamespace, Value]
+          NS: !Sub "{{resolve:ssm:/uni-prop/${Stage}/UnicornWebNamespace}}"
       RetentionInDays: !FindInMap [LogsRetentionPeriodMap, !Ref Stage, Days]
 
   # Permissions to allow EventBridge to send logs to CloudWatch


### PR DESCRIPTION
**Issue number:**
N/A

## Summary
Moving namespace definition to shared infra

### Changes

- removed namespace ssm param from service templates
- replaced map implementation with ssm resolver

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-samples/aws-serverless-developer-experience-workshop-dotnet/blob/develop/.github/semantic.yml)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
