### PR TITLE
fix: cross-runtime consistency fixes

### DIFF
--- a/Unicorn.Approvals/ApprovalsService.Tests/ApprovalsService.Tests.csproj
+++ b/Unicorn.Approvals/ApprovalsService.Tests/ApprovalsService.Tests.csproj
@@ -24,16 +24,16 @@
     </ItemGroup>
     <ItemGroup>
       <None Update="events\DynamoDbStreamEvents\contract_status_changed_draft.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
       <None Update="events\DynamoDbStreamEvents\contract_status_draft_waiting_for_approval.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
       <None Update="events\DynamoDbStreamEvents\contract_status_changed_approved_waiting_for_approval.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
       <None Update="events\DynamoDbStreamEvents\contract_status_changed_approved.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
       <None Update="events\StreamEvents\contract_status_changed_approved.json">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Unicorn.Contracts/ContractsService/ContractEventHandler.cs
+++ b/Unicorn.Contracts/ContractsService/ContractEventHandler.cs
@@ -164,7 +164,7 @@ public class ContractEventHandler
             Logger.LogInformation(response);
 
             // Add custom metric for "New Contracts"
-            Metrics.AddMetric("NewContracts", 1, MetricUnit.Count, MetricResolution.Standard);
+            Metrics.AddMetric("ContractCreated", 1, MetricUnit.Count, MetricResolution.Standard);
         }
         catch (ConditionalCheckFailedException e)
         {
@@ -222,8 +222,9 @@ public class ContractEventHandler
             };
 
             var response = await _dynamoDbClient.UpdateItemAsync(request);
-        
+
             Logger.LogInformation(response);
+            Metrics.AddMetric("ContractUpdated", 1, MetricUnit.Count, MetricResolution.Standard);
         }
         catch (ConditionalCheckFailedException e)
         {


### PR DESCRIPTION
**Issue number:** #82

## Summary

### Changes

Fixes to align the .NET runtime with Java, Python, and TypeScript for functional equivalence and cross-runtime consistency.

**Contracts Service (`Unicorn.Contracts`)**
- `ContractEventHandler.cs` — `CreateContractAsync`: renamed metric from `"NewContracts"` to `"ContractCreated"` to match the canonical metric name used by all other runtimes
- `ContractEventHandler.cs` — `UpdateContractAsync`: added `Metrics.AddMetric("ContractUpdated", 1, MetricUnit.Count, MetricResolution.Standard)` after a successful `UpdateItemAsync` call — the update path previously emitted no custom metric

### User experience

**Before:** Contract creation emitted a `NewContracts` metric (inconsistent with other runtimes). Contract updates emitted no custom metric at all.

**After:** Contract creation emits `ContractCreated` and contract updates emit `ContractUpdated`, consistent with Java, Python, and TypeScript.

## Checklist

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://github.com/aws-samples/aws-serverless-developer-experience-workshop-dotnet/blob/develop/.github/semantic.yml)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.